### PR TITLE
added config parameter for the default document page

### DIFF
--- a/DrupalTWDocs.inc
+++ b/DrupalTWDocs.inc
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+include_once('common/TWDocs.inc');
+
+/**
+ * Defines a logger object for TW Sparql module to provide feedback to
+ * users specific to Drupal.
+ * @author pattoe 
+ * @author pwest
+ */
+class DrupalTWDocsLogger implements TWDocsLogger {
+  protected $config;
+
+  public static function init() {
+    TWDocs::$logger = new DrupalTWDocsLogger();
+  }
+  
+  public function __construct() {
+    $this->config = \Drupal::config('twdocs.settings');
+  }
+  
+  /**
+   * Return whether debugging is turned on or not
+   */
+  public function shouldDebug() {
+    return $this->config->get('enable_debug', FALSE) ;
+  }
+
+  /**
+   * Set whether or not we should debug
+   */
+  public function enableDebug($val) {
+  }
+
+  /**
+   * Logs a string as an error.
+   * @param string $str String to log to the error console. 
+   */
+  public function logError($str) {
+    if( $this->shouldDebug() ) {
+      \Drupal::logger('twdocs')->error($str);
+    }
+  }
+  
+  /**
+   * Logs a string as a warning
+   * @param string $str String to log to the warning console. 
+   */
+  public function logWarning($str) {
+    if( $this->shouldDebug() ) {
+      \Drupal::logger('twdocs')->warning($str);
+    }
+  }
+  
+  /**
+   * Logs a string as a status
+   * @param string $str String to log to the status console. 
+   */
+  public function logStatus($str) {
+    if( $this->shouldDebug() ) {
+      \Drupal::logger('twdocs')->info($str);
+    }
+  }
+}
+
+class DrupalTWDocs extends TWDocs {
+  /**
+   * Object with configuration for geshifilter.
+   *
+   * @var object
+   */
+  protected $config;
+
+  public static function init() {
+    TWDocs::$engine = new DrupalTWDocs();
+  }
+
+  public function __construct() {
+    $this->config = \Drupal::config('twdocs.settings');
+  }
+  
+  public function shouldDebug() {
+    return TWDocs::getLogger()->shouldDebug() ;
+  }
+  
+  public function enableDebug($val) {
+    TWDocs::getLogger()->enableDebug($val) ;
+  }
+  
+  public function getBaseURI() {
+    return $this->config->get('baseuri', 'http://tw.rpi.edu/media');
+  }
+
+  public function setBaseURI($val) {
+  }
+  
+  public function getServiceID() {
+    return $this->config->get('serviceid', 'tw.rpi.edu');
+  }
+
+  public function setServiceID($val) {
+  }
+
+  public function getApiKey() {
+    return $this->config->get('apikey', 'XXXX');
+  }
+
+  public function setApiKey($val) {
+  }
+
+  public function getDefaultDocPage() {
+    return $this->config->get('defaultdocpage', 'https://tw.rpi.edu/web/doc/Document');
+  }
+
+  public function setDefaultDocPage($val) {
+  }
+}
+
+// Could have just used the DrupalTWDocs static function init to
+// initialize all three of these, but could be the case where someone
+// wants to use different loggers and caching mechanisms instead of the
+// Drupal one here.
+DrupalTWDocs::init();
+DrupalTWDocsLogger::init();
+

--- a/config/install/twdocs.settings.yml
+++ b/config/install/twdocs.settings.yml
@@ -1,4 +1,5 @@
 baseuri: 'http://tw.rpi.edu/media'
 serviceid: 'tw.rpi.edu'
 apikey: 'xxxx'
+defaultdocpage: 'https://tw.rpi.edu/web/doc/Document'
 

--- a/config/schema/twdocs.schema.yml
+++ b/config/schema/twdocs.schema.yml
@@ -11,4 +11,7 @@ twdocs.settings:
     apikey:
       type: string
       label: 'The API key needed for hashing the request for authentication purposes.'
+    defaultdocpage:
+      type: string
+      label: 'The default document page when one does not exist for the media file.'
 

--- a/src/Form/TWDocsSettingsForm.php
+++ b/src/Form/TWDocsSettingsForm.php
@@ -61,6 +61,12 @@ class TWDocsSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('apikey'),
       '#description' => $this->t('The API key needed for hashing the request for authentication purposes.'),
     ];
+    $form['settings']['defaultdocpage'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Default Document Page:'),
+      '#default_value' => $config->get('defaultdocpage'),
+      '#description' => $this->t('The default document page when one does not exist for the media file.'),
+    ];
 
     return parent::buildForm($form, $form_state);
   }
@@ -79,6 +85,9 @@ class TWDocsSettingsForm extends ConfigFormBase {
     if ($form_state->getValue('apikey') == "") {
       $form_state->setErrorByName('apikey', $this->t('The api key is required in order to upload media and store information'));
     }
+    if ($form_state->getValue('defaultdocpage') == "") {
+      $form_state->setErrorByName('defaultdocpage', $this->t('The default document page is required in order to display semantic representation of the media'));
+    }
   }
 
   /**
@@ -90,7 +99,8 @@ class TWDocsSettingsForm extends ConfigFormBase {
       $config = $this->config('twdocs.settings');
       $config->set('baseuri', $form_state->getValue('baseuri'))
         ->set('serviceid', $form_state->getValue('serviceid'))
-        ->set('apikey', $form_state->getValue('apikey'));
+        ->set('apikey', $form_state->getValue('apikey'))
+        ->set('defaultdocpage', $form_state->getValue('defaultdocpage'));
       $config->save();
       parent::submitForm($form, $form_state);
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! Here’s a template to help you format your PR.
 
Your title should look like: UXTALK-NUM Clear, brief title using imperative tense
For example: UXTALK-104 Refactor web consumer to handle API prefix removal
-->
 
### What does this PR do?
Adds to configuration the default document page for documents that do not have their own page. 
 
### Motivation and context
 #3 
 
### Screenshots or videos, if appropriate
![screen shot 2018-05-03 at 8 35 13 pm](https://user-images.githubusercontent.com/1447926/39611027-8c8c4958-4f11-11e8-94b0-ca5d82852b1d.png)
 
 
### How has this been tested?
 Tested locally with different document tags to make sure the media links link to that default page with the uri of the document as the uri query string parameter
 
### Checklist
 
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
 
* [x] Renders and functions properly in all supported browsers
* [x] Automated tests written and passing (n/a)
* [x] Documentation created or updated, including (n/a)
* [x] There is a single commit with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that starts with the Jira ticket
 
<!-- If any of the above need further details, you should include those here. -->
 
### How does this PR make you feel?
 
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
 
![On fire](https://media.giphy.com/media/tjLaaAfBm3LR6/giphy.gif)
