### PR TITLE
twdocs-0006 differentiate media uri from instance uri in configuration

### DIFF
--- a/DrupalTWDocs.inc
+++ b/DrupalTWDocs.inc
@@ -92,11 +92,18 @@ class DrupalTWDocs extends TWDocs {
     TWDocs::getLogger()->enableDebug($val) ;
   }
   
-  public function getBaseURI() {
-    return $this->config->get('baseuri', 'http://tw.rpi.edu/media');
+  public function getMediaURI() {
+    return $this->config->get('mediauri', 'http://tw.rpi.edu/media');
   }
 
-  public function setBaseURI($val) {
+  public function setMediaURI($val) {
+  }
+  
+  public function getInstanceURI() {
+    return $this->config->get('instanceuri', 'http://tw.rpi.edu/media');
+  }
+
+  public function setInstanceURI($val) {
   }
   
   public function getServiceID() {

--- a/config/install/twdocs.settings.yml
+++ b/config/install/twdocs.settings.yml
@@ -1,4 +1,5 @@
-baseuri: 'http://tw.rpi.edu/media'
+mediauri: 'http://tw.rpi.edu/media'
+instanceuri: 'http://tw.rpi.edu/media'
 serviceid: 'tw.rpi.edu'
 apikey: 'xxxx'
 defaultdocpage: 'https://tw.rpi.edu/web/doc/Document'

--- a/config/schema/twdocs.schema.yml
+++ b/config/schema/twdocs.schema.yml
@@ -2,9 +2,12 @@ twdocs.settings:
   type: config_object
   label: "Setting for twdocs module"
   mapping:
-    baseuri:
+    mediauri:
       type: string
       label: 'Base URI for Document Store'
+    instanceuri:
+      type: string
+      label: 'Base Instance URI'
     serviceid:
       type: string
       label: 'The service identifier the module should use when talking to the media manager.'

--- a/src/Form/TWDocsSettingsForm.php
+++ b/src/Form/TWDocsSettingsForm.php
@@ -43,11 +43,17 @@ class TWDocsSettingsForm extends ConfigFormBase {
       '#collapsible' => FALSE,
     ];
 
-    $form['settings']['baseuri'] = [
+    $form['settings']['mediauri'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Base URI for Document Store:'),
-      '#default_value' => $config->get('baseuri'),
-      '#description' => $this->t('Location where media will be uploaded and semantic information stored'),
+      '#default_value' => $config->get('mediauri'),
+      '#description' => $this->t('Location where media will be uploaded'),
+    ];
+    $form['settings']['instanceuri'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Base Instance URI:'),
+      '#default_value' => $config->get('instanceuri'),
+      '#description' => $this->t('Base URI of semantic instance data stored for the media'),
     ];
     $form['settings']['serviceid'] = [
       '#type' => 'textfield',
@@ -76,8 +82,11 @@ class TWDocsSettingsForm extends ConfigFormBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     // Check if automatically managed style sheet is posible.
-    if ($form_state->getValue('baseuri') == "") {
-      $form_state->setErrorByName('baseuri', $this->t('The base URI for media must be specified in order to upload media and store information'));
+    if ($form_state->getValue('mediauri') == "") {
+      $form_state->setErrorByName('mediauri', $this->t('The base URI for media must be specified in order to upload media'));
+    }
+    if ($form_state->getValue('instanceuri') == "") {
+      $form_state->setErrorByName('instanceuri', $this->t('The base URI for media instance information'));
     }
     if ($form_state->getValue('serviceid') == "") {
       $form_state->setErrorByName('serviceid', $this->t('The service ID is required in order to upload media and store information'));
@@ -97,7 +106,8 @@ class TWDocsSettingsForm extends ConfigFormBase {
     $errors = $form_state->getErrors();
     if (count($errors) == 0) {
       $config = $this->config('twdocs.settings');
-      $config->set('baseuri', $form_state->getValue('baseuri'))
+      $config->set('mediauri', $form_state->getValue('mediauri'))
+        ->set('instanceuri', $form_state->getValue('instanceuri'))
         ->set('serviceid', $form_state->getValue('serviceid'))
         ->set('apikey', $form_state->getValue('apikey'))
         ->set('defaultdocpage', $form_state->getValue('defaultdocpage'));


### PR DESCRIPTION
<!--
Thank you for your contribution! Here’s a template to help you format your PR.
 
Your title should look like: UXTALK-NUM Clear, brief title using imperative tense
For example: UXTALK-104 Refactor web consumer to handle API prefix removal
-->
 
### What does this PR do?
Differentiates between the base media URI, where the media lives, and the base instance uri, the semantic representation of the media
 
### Motivation and context
#6 
 
### Screenshots or videos, if appropriate
![screen shot 2018-05-03 at 9 55 20 pm](https://user-images.githubusercontent.com/1447926/39612567-dee3650e-4f1d-11e8-8276-33d70f21944a.png)

 
### How has this been tested?
tested locally both setting the configuration and displaying media on a page
 
### Checklist
 
<!-- Put an `x` in all the boxes that apply and are complete. If an item does not apply, put an `x` in it anyway and add “[n/a]” to the end of the line. If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
 
* [x] Renders and functions properly in all supported browsers
* [x] Automated tests written and passing (n/a)
* [x] Documentation created or updated, including (n/a)
* [x] There is a single commit with a [Good commit message](https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92) that starts with the Jira ticket
 
<!-- If any of the above need further details, you should include those here. -->
 
### How does this PR make you feel?
 
<!--
1. Find a gif: http://giphy.com/categories/
2. Click 'Copy link'
3. Copy the 'GIF Link', paste it in place of the URL below, and update the alt text
-->
 
![because I'm batman](https://media.giphy.com/media/CI63TIzJND0t2/giphy.gif)
